### PR TITLE
Add unit tests for project methods

### DIFF
--- a/src/test/java/com/training/mentoring/demo/controllers/ClientRestControllerTest.java
+++ b/src/test/java/com/training/mentoring/demo/controllers/ClientRestControllerTest.java
@@ -1,0 +1,81 @@
+package com.training.mentoring.demo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.training.mentoring.demo.dto.ContactInfoDto;
+import com.training.mentoring.demo.entities.ContactInfoEntity;
+import com.training.mentoring.demo.impl.ContactInfoServiceImpl;
+import com.training.mentoring.demo.util.MappingObjectsUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ClientRestController.class)
+@Tag("controller")
+public class ClientRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ContactInfoServiceImpl service;
+
+    @Test
+    void nuevoEndpoint_shouldReturnDemoMessage() throws Exception {
+        mockMvc.perform(get("/contact-book/demo"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("This is a demo endpoint for testing purposes"));
+    }
+
+    @Test
+    void getAllContacts_shouldReturnMappedDtos() throws Exception {
+        ContactInfoEntity entity = new ContactInfoEntity();
+        entity.setEmail("a@b.com");
+        when(service.getAllContacts()).thenReturn(List.of(entity));
+
+        ContactInfoDto dto = MappingObjectsUtil.mapEntityToDto.apply(entity);
+        mockMvc.perform(get("/contact-book/all-contacts"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(List.of(dto))));
+    }
+
+    @Test
+    void postContact_shouldInvokeServiceSave() throws Exception {
+        ContactInfoDto dto = new ContactInfoDto();
+        dto.setEmail("c@d.com");
+        String json = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/contact-book/save-contact")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+
+        verify(service).saveContactInfo(Mockito.any(ContactInfoEntity.class));
+    }
+
+    @Test
+    void deleteContact_shouldReturnServiceResponse() throws Exception {
+        when(service.deleteContactByEmail("a@b.com"))
+                .thenReturn(ResponseEntity.ok("ok"));
+
+        mockMvc.perform(delete("/contact-book/a@b.com"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("ok"));
+    }
+}

--- a/src/test/java/com/training/mentoring/demo/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/training/mentoring/demo/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,21 @@
+package com.training.mentoring.demo.exception;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("exception")
+public class GlobalExceptionHandlerTest {
+
+    @Test
+    void handleRuntimeException_shouldReturn500() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        RuntimeException ex = new RuntimeException("boom");
+        ResponseEntity<String> response = handler.handleRuntimeExeption(ex);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertTrue(response.getBody().contains("boom"));
+    }
+}

--- a/src/test/java/com/training/mentoring/demo/impl/ContactInfoServiceImplTest.java
+++ b/src/test/java/com/training/mentoring/demo/impl/ContactInfoServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.training.mentoring.demo.impl;
+
+import com.training.mentoring.demo.entities.ContactInfoEntity;
+import com.training.mentoring.demo.repositories.ContactInfoRepository;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("service")
+public class ContactInfoServiceImplTest {
+
+    @Mock
+    private ContactInfoRepository repository;
+
+    @InjectMocks
+    private ContactInfoServiceImpl service;
+
+    @Test
+    void getContactById_shouldDelegateToRepository() {
+        ContactInfoEntity entity = new ContactInfoEntity();
+        when(repository.getReferenceById(1L)).thenReturn(entity);
+
+        ContactInfoEntity result = service.getContactById(1L);
+        assertSame(entity, result);
+        verify(repository).getReferenceById(1L);
+    }
+
+    @Test
+    void getAllContacts_shouldReturnAll() {
+        when(repository.findAll()).thenReturn(Collections.emptyList());
+        assertTrue(service.getAllContacts().isEmpty());
+        verify(repository).findAll();
+    }
+
+    @Test
+    void saveContactInfo_shouldCallRepositorySave() {
+        ContactInfoEntity entity = new ContactInfoEntity();
+        service.saveContactInfo(entity);
+        verify(repository).save(entity);
+    }
+
+    @Test
+    void deleteContactByEmail_whenFound_shouldReturnOk() {
+        String email = "a@b.com";
+        ContactInfoEntity entity = new ContactInfoEntity();
+        when(repository.findByEmail(email)).thenReturn(Optional.of(entity));
+        ResponseEntity<String> response = service.deleteContactByEmail(email);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(repository).deleteByEmail(email);
+    }
+
+    @Test
+    void deleteContactByEmail_whenNotFound_shouldReturnNotFound() {
+        String email = "not@found.com";
+        when(repository.findByEmail(email)).thenReturn(Optional.empty());
+        ResponseEntity<String> response = service.deleteContactByEmail(email);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(repository, never()).deleteByEmail(anyString());
+    }
+}

--- a/src/test/java/com/training/mentoring/demo/repositories/ContactInfoRepositoryTest.java
+++ b/src/test/java/com/training/mentoring/demo/repositories/ContactInfoRepositoryTest.java
@@ -1,0 +1,40 @@
+package com.training.mentoring.demo.repositories;
+
+import com.training.mentoring.demo.entities.ContactInfoEntity;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Tag("repository")
+public class ContactInfoRepositoryTest {
+
+    @Autowired
+    private ContactInfoRepository repository;
+
+    @Test
+    void findByEmail_shouldReturnSavedEntity() {
+        ContactInfoEntity entity = new ContactInfoEntity();
+        entity.setEmail("repo@test.com");
+        repository.save(entity);
+
+        Optional<ContactInfoEntity> result = repository.findByEmail("repo@test.com");
+        assertTrue(result.isPresent());
+        assertEquals("repo@test.com", result.get().getEmail());
+    }
+
+    @Test
+    void deleteByEmail_shouldRemoveEntity() {
+        ContactInfoEntity entity = new ContactInfoEntity();
+        entity.setEmail("delete@test.com");
+        repository.save(entity);
+
+        repository.deleteByEmail("delete@test.com");
+        assertTrue(repository.findByEmail("delete@test.com").isEmpty());
+    }
+}

--- a/src/test/java/com/training/mentoring/demo/util/MappingObjectsUtilTest.java
+++ b/src/test/java/com/training/mentoring/demo/util/MappingObjectsUtilTest.java
@@ -1,0 +1,60 @@
+package com.training.mentoring.demo.util;
+
+import com.training.mentoring.demo.dto.ContactInfoDto;
+import com.training.mentoring.demo.entities.ContactInfoEntity;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("util")
+public class MappingObjectsUtilTest {
+
+    @Test
+    void mapDtoToEntity_shouldCopyAllFields() {
+        ContactInfoDto dto = new ContactInfoDto();
+        dto.setFirstName("John");
+        dto.setLastName("Doe");
+        dto.setEmail("john@doe.com");
+        dto.setCountry("US");
+        dto.setCity("NYC");
+        dto.setStreet("Main St");
+        dto.setPostalCode("12345");
+        dto.setPhoneNumber("1111");
+
+        ContactInfoEntity entity = MappingObjectsUtil.mapDtoToEntity.apply(dto);
+
+        assertEquals(dto.getFirstName(), entity.getFirstName());
+        assertEquals(dto.getLastName(), entity.getLastName());
+        assertEquals(dto.getEmail(), entity.getEmail());
+        assertEquals(dto.getCountry(), entity.getCountry());
+        assertEquals(dto.getCity(), entity.getCity());
+        assertEquals(dto.getStreet(), entity.getStreet());
+        assertEquals(dto.getPostalCode(), entity.getPostalCode());
+        assertEquals(dto.getPhoneNumber(), entity.getPhoneNumber());
+    }
+
+    @Test
+    void mapEntityToDto_shouldCopyAllFields() {
+        ContactInfoEntity entity = new ContactInfoEntity();
+        entity.setFirstName("Jane");
+        entity.setLastName("Doe");
+        entity.setEmail("jane@doe.com");
+        entity.setCountry("US");
+        entity.setCity("LA");
+        entity.setStreet("Second St");
+        entity.setPostalCode("54321");
+        entity.setPhoneNumber("2222");
+
+        ContactInfoDto dto = MappingObjectsUtil.mapEntityToDto.apply(entity);
+
+        assertEquals(entity.getFirstName(), dto.getFirstName());
+        assertEquals(entity.getLastName(), dto.getLastName());
+        assertEquals(entity.getEmail(), dto.getEmail());
+        assertEquals(entity.getCountry(), dto.getCountry());
+        assertEquals(entity.getCity(), dto.getCity());
+        assertEquals(entity.getStreet(), dto.getStreet());
+        assertEquals(entity.getPostalCode(), dto.getPostalCode());
+        assertEquals(entity.getPhoneNumber(), dto.getPhoneNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- implement utility tests for mapping conversions
- add service layer unit tests with Mockito
- create repository integration tests using DataJpaTest
- test controller endpoints with MockMvc
- verify global exception handler behavior

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864589ea9848333b68cb8c58a96ec8f